### PR TITLE
Log in to the frontend via email

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,5 @@ To run the backend/frontend development server:
 ```sh
 $ make run
 ```
+
+Unless `SENDGRID_USERNAME` and `SENDGRID_PASSWORD` are set, sent emails will appear in the `./tmp/emails/` directory.

--- a/api/config/settings/local.py
+++ b/api/config/settings/local.py
@@ -7,13 +7,22 @@ from .base import *
 BASE_NAME = BASE_DOMAIN = "localhost"
 BASE_URL = f"http://{BASE_DOMAIN}:8000"
 
+###############################################################################
+# Core
+
 DEBUG = True
 
 SECRET_KEY = 'dev'
 
 INSTALLED_APPS += ['django_extensions']
 
+###############################################################################
+# Logging
+
 LOGGING['loggers']['api']['level'] = os.getenv('LOG_LEVEL', 'INFO')
+
+###############################################################################
+# Databases
 
 DATABASES = {
     'default': {
@@ -23,6 +32,16 @@ DATABASES = {
     'remote': dj_database_url.config(),
 }
 
+###############################################################################
+# Authentication
+
 AUTH_PASSWORD_VALIDATORS = []
 
+###############################################################################
+# Email
+
 DEFAULT_FROM_EMAIL = f"Voter Engagement {BASE_NAME} <noreply@{BASE_DOMAIN}>"
+
+if not (os.getenv('SENDGRID_USERNAME') and os.getenv('SENDGRID_PASSWORD')):
+    EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
+    EMAIL_FILE_PATH = os.path.join(PROJECT_ROOT, 'tmp', 'emails')

--- a/api/config/settings/production.py
+++ b/api/config/settings/production.py
@@ -25,7 +25,7 @@ ALLOWED_HOSTS = [
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 ###############################################################################
-# Database
+# Databases
 
 DATABASES = {}
 DATABASES['default'] = dj_database_url.config()

--- a/api/config/settings/staging.py
+++ b/api/config/settings/staging.py
@@ -7,11 +7,24 @@ BASE_NAME = os.environ['HEROKU_APP_NAME']
 BASE_DOMAIN = f"{BASE_NAME}.herokuapp.com"
 BASE_URL = f"https://{BASE_DOMAIN}"
 
+###############################################################################
+# Core
+
 ALLOWED_HOSTS += [
     '.herokuapp.com',
 ]
 
+###############################################################################
+# Email
+
 DEFAULT_FROM_EMAIL = f"Voter Engagement {BASE_NAME} <noreply@{BASE_DOMAIN}>"
 
-ROLLBAR['environment'] = os.getenv('ROLLBAR_ENVIRONMENT', 'staging')
+###############################################################################
+# Logging
+
 LOGGING['handlers']['rollbar']['environment'] = os.getenv('ROLLBAR_ENVIRONMENT', 'staging')
+
+###############################################################################
+# Rollbar
+
+ROLLBAR['environment'] = os.getenv('ROLLBAR_ENVIRONMENT', 'staging')

--- a/api/config/settings/test.py
+++ b/api/config/settings/test.py
@@ -4,11 +4,17 @@ from .base import *
 # They are only needed to seed data in staging and local
 BASE_URL = "http://example.com"
 
+###############################################################################
+# Core
+
 TEST = True
 
 DEBUG = True
 
 SECRET_KEY = 'test'
+
+###############################################################################
+# Databases
 
 DATABASES = {
     'default': {
@@ -16,5 +22,8 @@ DATABASES = {
         'NAME': 'voterengagement_test',
     }
 }
+
+###############################################################################
+# Logging
 
 LOGGING['loggers']['api']['level'] = 'DEBUG'

--- a/api/core/helpers.py
+++ b/api/core/helpers.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 def send_login_email(user, request):
     assert user.email, f"User has no email: {user}"
 
-    base = reverse('redirector', args=["api/registration"], request=request)
+    base = reverse('redirector', args=["login"], request=request)
     token = get_query_string(user)
     url = base + token
 

--- a/api/ui/views.py
+++ b/api/ui/views.py
@@ -15,10 +15,12 @@ def index(request):
 
 
 def redirector(request, path):
-    if not request.user.is_authenticated:
+    if request.user.is_authenticated:
+        log.info(f"Authenticated from email: {request.user.email}")
+    else:
         log.warning("Failed to authenticate from token")
 
     url = "/" + path
-    log.info(f"Redirecting to {url}")
+    log.info(f"Redirecting to: {url}")
 
     return redirect(url)

--- a/web_client/app/awaiting-confirmation/awaiting-confirmation.tsx
+++ b/web_client/app/awaiting-confirmation/awaiting-confirmation.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { Voter } from 'models';
+import { go } from 'router';
+
+import { MainContentWrapper } from 'main-content-wrapper/main-content-wrapper';
+import { ShortInput } from 'forms/short-input/short-input';
+import { Button } from 'button/button';
+
+// CSS
+import { styles, vars, css, centeredBox } from 'styles/css';
+
+
+export type AwaitingConfirmationProps = {
+
+};
+
+@observer
+export class AwaitingConfirmation extends React.Component<AwaitingConfirmationProps, {}> {
+  render() {
+    return (
+      <MainContentWrapper>
+        <div {...style.box}>
+          <div {...style.maxWidth}>
+            <h1>Thanks! Check your email!</h1>
+            <p>We've sent you a link. Click it to log in.</p>
+          </div>
+        </div>
+      </MainContentWrapper>
+    );
+  }
+}
+
+const style = styles({
+  box: {
+    padding: vars.spacing
+  },
+  maxWidth: {
+    textAlign: 'center'
+    maxWidth: 400,
+    margin: '0 auto'
+  },
+});

--- a/web_client/app/awaiting-confirmation/awaiting-confirmation.tsx
+++ b/web_client/app/awaiting-confirmation/awaiting-confirmation.tsx
@@ -36,7 +36,7 @@ const style = styles({
     padding: vars.spacing
   },
   maxWidth: {
-    textAlign: 'center'
+    textAlign: 'center',
     maxWidth: 400,
     margin: '0 auto'
   },

--- a/web_client/app/forms/labelled/labelled.tsx
+++ b/web_client/app/forms/labelled/labelled.tsx
@@ -61,7 +61,7 @@ let style = styles({
     fontWeight: 600,
   },
   errors: {
-    color: vars.color.warn,
+    color: 'rgba(255, 220, 200, .9)',
     fontSize: 14,
     float: 'right',
     lineHeight: 1.6

--- a/web_client/app/home/login.tsx
+++ b/web_client/app/home/login.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
+import { go } from 'router';
 
 import { MainContentWrapper } from 'main-content-wrapper/main-content-wrapper';
 import { ShortInput } from 'forms/short-input/short-input';
@@ -17,11 +18,30 @@ export type LoginProps = {
 @observer
 export class Login extends React.Component<LoginProps, {}> {
   state = {
-    email: ""
+    email: "",
+    errors: {} as {
+      email: string[],
+    }
   }
 
   componentWillMount() {
     this.setState({});
+  }
+
+  componentDidMount() {
+    API.get('registration/').then(data => {
+      const registered = data['registered'];
+      console.log("Registered: " + registered);
+      if (registered === true) {
+        go('/registration-verified');
+      } else if (registered === false) {
+        go('/not-registered');
+      } else {
+        go('/');
+      }
+    }).catch(e => {
+      this.setState({errors: e})
+    })
   }
 
   setter(name: string) {
@@ -41,8 +61,8 @@ export class Login extends React.Component<LoginProps, {}> {
       <MainContentWrapper>
         <div {...style.box}>
           <div {...style.maxWidth}>
-            <h1 {...style.heading}>Welcome Back</h1>
-            <p>Let us send you an email to return to your account.</p>
+            <h1 {...style.heading}>Welcome Back!</h1>
+            <p>Let us send you an email containing a link to get you back into to your account.</p>
             <ShortInput label="Email" onChange={this.setter('email')} placeholder="you@yourdomain.com" value={this.state.email}/>
             <Button action={this.submit} css={style.button}> Send me a link!</Button>
             <Link to='/'>I still need an account.</Link>

--- a/web_client/app/home/login.tsx
+++ b/web_client/app/home/login.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+
+import { MainContentWrapper } from 'main-content-wrapper/main-content-wrapper';
+import { ShortInput } from 'forms/short-input/short-input';
+import { Button } from 'button/button';
+import { Link } from 'link/link';
+
+import { styles, vars, css, centeredBox } from 'styles/css';
+
+import API from 'api/api';
+
+export type LoginProps = {
+
+};
+
+@observer
+export class Login extends React.Component<LoginProps, {}> {
+  state = {
+    email: ""
+  }
+
+  componentWillMount() {
+    this.setState({});
+  }
+
+  setter(name: string) {
+    return (value: string) => {
+      this.setState({[name]: value});
+    }
+  }
+
+  submit = () => {
+    const { email } = this.state;
+    console.log("Sending email: " + email);
+    return API.post('login-email/', {email: email});
+  }
+
+  render() {
+    return (
+      <MainContentWrapper>
+        <div {...style.box}>
+          <div {...style.maxWidth}>
+            <h1 {...style.heading}>Welcome Back</h1>
+            <p>Let us send you an email to return to your account.</p>
+            <ShortInput label="Email" onChange={this.setter('email')} placeholder="you@yourdomain.com" value={this.state.email}/>
+            <Button action={this.submit} css={style.button}> Send me a link!</Button>
+            <Link to='/'>I still need an account.</Link>
+          </div>
+        </div>
+      </MainContentWrapper>
+    );
+  }
+}
+
+const style = styles({
+  button: {
+    margin: '0 auto',
+    display: 'block'
+  },
+  box: {
+    padding: vars.spacing
+  },
+  heading: {
+    marginBottom: vars.spacing
+  },
+  maxWidth: {
+    maxWidth: 400,
+    margin: '0 auto'
+  }
+});

--- a/web_client/app/login/login.tsx
+++ b/web_client/app/login/login.tsx
@@ -20,7 +20,10 @@ export type LoginProps = {
 export class Login extends React.Component<LoginProps, {}> {
   state = {
     ready: false,
-    email: ""
+    email: "",
+    errors: null as {
+      email: string[]
+    }
   }
 
   componentWillMount() {
@@ -47,7 +50,9 @@ export class Login extends React.Component<LoginProps, {}> {
     const { email } = this.state;
     return API.post('login-email/', {email: email}).then(
       () => go("/awaiting-confirmation")
-    );
+    ).catch(
+      () => this.setState({errors: {email: ["Sorry, I don't recognize that email"]}})
+    )
   }
 
   render() {
@@ -60,7 +65,7 @@ export class Login extends React.Component<LoginProps, {}> {
             <h1 {...style.heading}>Welcome Back!</h1>
             <p>Let us send you an email containing a link to get you back into to your account.</p>
             <form onSubmit={e => { this.submit(); e.preventDefault(); }}>
-              <ShortInput label="Email" autofocus onChange={this.setter('email')} value={this.state.email}/>
+              <ShortInput label="Email" autofocus onChange={this.setter('email')} errors={this.state.errors.email} value={this.state.email}/>
               <Button action={this.submit} css={style.button}> Send me a link!</Button>
               <div {...style.note}><Link to='/'>I still need an account.</Link></div>
             </form>

--- a/web_client/app/login/login.tsx
+++ b/web_client/app/login/login.tsx
@@ -26,11 +26,11 @@ export class Login extends React.Component<LoginProps, {}> {
   componentWillMount() {
     Voter.fetchMe().then(voter => {
       if (voter.registered === true) {
-        go('/registration-verified');
+        go('/registration-verified', {}, true);
       } else if (voter.registered === false) {
-        go('/not-registered');
+        go('/not-registered', {}, true);
       } else {
-        go('/');
+        go('/', {}, true);
       }
     }).catch(e => {
       this.setState({errors: e, ready: true})

--- a/web_client/app/models/voter/voter-service.ts
+++ b/web_client/app/models/voter/voter-service.ts
@@ -12,4 +12,17 @@ export const VoterService = new class {
       zip: string): Promise<IncomingRegistrationJSON> {
     return API.get(`registration/?first_name=${firstName}&last_name=${lastName}&birth_date=${birthDate}&zip_code=${zip}`);
   }
+
+  signUp(
+    email: string,
+    firstName: string, 
+    lastName: string, 
+    birthDate: string, 
+    zip: string): Promise<IncomingRegistrationJSON> {
+    return API.get(`registration/?email=${email}&first_name=${firstName}&last_name=${lastName}&birth_date=${birthDate}&zip_code=${zip}`);
+  }
+  
+  me(): Promise<IncomingRegistrationJSON> {
+    return API.get(`registration/`);
+  }
 }

--- a/web_client/app/models/voter/voter.tsx
+++ b/web_client/app/models/voter/voter.tsx
@@ -7,14 +7,63 @@ export class Voter {
   @observable birthDate: string
   @observable zipCode: string
   @observable registered: boolean
+  @observable email: string
+  @observable signedUp: boolean = false;
+  static currentUserStore: CurrentUserStore;
 
   @action
   checkRegistration() {
     return VoterService.checkRegistration(this.firstName, this.lastName, this.birthDate, this.zipCode).then(
       result => {
-        Object.assign(this, result);
+        this.updateFromFetch(result);
         return this.registered;
       }
     );
   }
+
+  signUp() {
+    return VoterService.signUp(this.email, this.firstName, this.lastName, this.birthDate, this.zipCode).then(
+      result => {
+        this.updateFromFetch(result);
+        return this.registered;
+      }
+    );
+  }
+
+  @action
+  static fetchMe() {
+    // If we've already fetched current user, don't refetch.
+    if (this.currentUserStore.fetched) return Promise.resolve(this.currentUser);
+    return VoterService.me().then(
+      json => {
+        this.currentUser.updateFromFetch(json);
+        this.currentUser.signedUp = true;
+        this.currentUserStore.fetched = true;
+        return this.currentUser;
+      }
+    );
+  }
+
+  @computed
+  static get currentUser() {
+    return this.currentUserStore.currentUser;
+  }
+
+  @action
+  updateFromFetch(json: IncomingRegistrationJSON) {
+    Object.assign(this, json);
+  }
+
+  @computed 
+  get me() {
+    return Voter.currentUserStore.currentUser;
+  }
 }
+
+// Mobx interacts poorly with static variables, so we store our statics as
+// instance variables in a singleton.
+class CurrentUserStore {
+  @observable fetched = false;
+  @observable currentUser = new Voter();
+}
+Voter.currentUserStore = new CurrentUserStore();

--- a/web_client/app/not-registered/not-registered.tsx
+++ b/web_client/app/not-registered/not-registered.tsx
@@ -21,7 +21,10 @@ export type NotRegisteredProps = {
 export class NotRegistered extends React.Component<NotRegisteredProps, {}> {
   state = {
     email: "",
-    awaitingConfirmation: false
+    awaitingConfirmation: false,
+    errors: {} as {
+      email: string[]
+    }
   }
 
   setter(name: string) {
@@ -36,7 +39,9 @@ export class NotRegistered extends React.Component<NotRegisteredProps, {}> {
     Voter.currentUser.email = this.state.email;
     Voter.currentUser.signUp().then(
       () => go('/awaiting-confirmation')
-    )
+    ).catch(
+      errors => this.setState({errors: errors})
+    );
   }
 
   register = () => {
@@ -56,7 +61,7 @@ export class NotRegistered extends React.Component<NotRegisteredProps, {}> {
             </div>
             {!Voter.currentUser.signedUp && <form onSubmit={e => { this.submit(); e.preventDefault(); }}>
               <p>You can also sign up to be reminded to vote in local elections.</p>
-              <ShortInput label="Email" onChange={this.setter('email')} type="email" value={this.state.email}/>
+              <ShortInput label="Email" onChange={this.setter('email')} errors={this.state.errors.email} type="email" value={this.state.email}/>
               <div {...style.buttons}>
                 <Link to="/registration-check" theme="transparent">Back</Link>
                 <Button action={this.submit} theme="warn">Sign Up</Button>

--- a/web_client/app/not-registered/not-registered.tsx
+++ b/web_client/app/not-registered/not-registered.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
+import { Voter } from 'models';
 
 import { MainContentWrapper } from 'main-content-wrapper/main-content-wrapper';
 import { ShortInput } from 'forms/short-input/short-input';
 import { Button } from 'button/button';
 import { Link } from 'link/link';
+import { go } from 'router';
 
 // CSS
 import { styles, vars, css, centeredBox } from 'styles/css';
@@ -17,8 +19,27 @@ export type NotRegisteredProps = {
 
 @observer
 export class NotRegistered extends React.Component<NotRegisteredProps, {}> {
+  state = {
+    email: "",
+    awaitingConfirmation: false
+  }
+
+  setter(name: string) {
+    return (value: string) => {
+      this.setState({[name]: value});
+    }
+  }
+
+  // Need to define action(s) associated with form buttons
 
   submit = () => {
+    Voter.currentUser.email = this.state.email;
+    Voter.currentUser.signUp().then(
+      () => go('/awaiting-confirmation')
+    )
+  }
+
+  register = () => {
     alert("Not implemented.")
   }
 
@@ -29,11 +50,21 @@ export class NotRegistered extends React.Component<NotRegisteredProps, {}> {
           <div {...style.maxWidth}>
             <div {...style.icon}><BigX size={100} color={vars.color.white} /></div>
             <h1 {...style.result}>You&rsquo;re not registered.</h1>
-            <p>Sorry! We couldn't find you using that information. You may not be registered. Find how to register yourself, or try checking again.</p>
-            <div {...style.buttons}>
-              <Link to="/registration-check" theme="transparent" css={style.button}>Try Again</Link>
-              <Button action={this.submit} theme="warn" css={style.button}>Register to Vote</Button>
+            <p>Sorry! We couldn't find you using that information. You may not be registered. Find how to register yourself, or <Link to="/registration-check">try checking again</Link>.</p>
+            <div {...style.registerButtons}>
+              <Button action={this.register} theme="warn" css={style.button}>Register to Vote</Button>
             </div>
+            {!Voter.currentUser.signedUp && <form onSubmit={e => { this.submit(); e.preventDefault(); }}>
+              <p>You can also sign up to be reminded to vote in local elections.</p>
+              <ShortInput label="Email" onChange={this.setter('email')} type="email" value={this.state.email}/>
+              <div {...style.buttons}>
+                <Link to="/registration-check" theme="transparent">Back</Link>
+                <Button action={this.submit} theme="warn">Sign Up</Button>
+              </div>
+            </form>}
+            {Voter.currentUser.signedUp && <form onSubmit={e => { this.submit(); e.preventDefault(); }}>
+              <p>We'll email you to remind you about upcoming elections.</p>
+            </form>}
           </div>
         </div>
       </MainContentWrapper>
@@ -58,6 +89,12 @@ const style = styles({
     display: 'flex',
     flexWrap: 'wrap',
     justifyContent: 'space-between'
+  },
+  registerButtons: {
+    marginTop: vars.spacing * 2,
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'center'
   },
   box: {
     padding: vars.spacing

--- a/web_client/app/registration-check/registration-check.tsx
+++ b/web_client/app/registration-check/registration-check.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react';
 import { Voter } from 'models';
 import { go } from 'router';
 
+import { Link } from 'link/link';
 import { MainContentWrapper } from 'main-content-wrapper/main-content-wrapper';
 import { ShortInput } from 'forms/short-input/short-input';
 import { Button } from 'button/button';
@@ -22,7 +23,6 @@ export class RegistrationCheck extends React.Component<RegistrationCheckProps, {
     lastName: "",
     birthDate: "",
     zipCode: "",
-    voter: null as Voter,
     errors: {} as {
       first_name: string[],
       last_name: string[],
@@ -31,9 +31,6 @@ export class RegistrationCheck extends React.Component<RegistrationCheckProps, {
     }
   }
 
-  componentWillMount() {
-    this.setState({voter: new Voter()});
-  }
 
   setter(name: string) {
     return (value: string) => {
@@ -42,7 +39,8 @@ export class RegistrationCheck extends React.Component<RegistrationCheckProps, {
   }
 
   submit = () => {
-    const { voter, firstName, lastName, birthDate, zipCode } = this.state;
+    const { firstName, lastName, birthDate, zipCode } = this.state;
+    const voter = Voter.currentUser;
     this.setState({errors: {}});
     Object.assign(voter, { firstName, lastName, birthDate, zipCode });
     voter.checkRegistration().then(r => {
@@ -67,7 +65,10 @@ export class RegistrationCheck extends React.Component<RegistrationCheckProps, {
             <ShortInput label="Birthday" onChange={this.setter('birthDate')} errors={this.state.errors.birth_date} value={this.state.birthDate} placeholder="YYYY-MM-DD" />
             <ShortInput label="Zip Code" onChange={this.setter('zipCode')} errors={this.state.errors.zip_code} value={this.state.zipCode}/>
             <div {...css(vars.clearFix)}><Button action={this.submit} css={style.button}>Check!</Button></div>
-            <div {...style.note}><p>You can also use the <a href="https://webapps.sos.state.mi.us/MVIC/">Secretary of State's website</a></p></div>
+            <div {...style.note}>
+            <p>You can also use the <a href="https://webapps.sos.state.mi.us/MVIC/">Secretary of State's website</a></p>
+            <p>Already signed up? <Link to="/login">Log in</Link></p>
+            </div>
           </form>
         </div>
       </MainContentWrapper>

--- a/web_client/app/registration-verified/registration-verified.tsx
+++ b/web_client/app/registration-verified/registration-verified.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import { go } from 'router';
+import { Voter } from 'models';
 
 import { MainContentWrapper } from 'main-content-wrapper/main-content-wrapper';
 import { ShortInput } from 'forms/short-input/short-input';
@@ -20,7 +21,6 @@ export type RegistrationVerifiedProps = {
 export class RegistrationVerified extends React.Component<RegistrationVerifiedProps, {}> {
   state = {
     email: "",
-    phoneNumber: "",
   }
 
   setter(name: string) {
@@ -32,7 +32,10 @@ export class RegistrationVerified extends React.Component<RegistrationVerifiedPr
   // Need to define action(s) associated with form buttons
 
   submit = () => {
-    alert("Not implemented")
+    Voter.currentUser.email = this.state.email;
+    Voter.currentUser.signUp().then(
+      () => go("/awaiting-confirmation")
+    )
   }
 
   render() {
@@ -44,13 +47,15 @@ export class RegistrationVerified extends React.Component<RegistrationVerifiedPr
               <CheckMark size={100} color={vars.color.white} />
             </div>
             <h1 {...style.result}>You&rsquo;re already registered&nbsp;to&nbsp;vote!</h1>
-            <p>Sign up to be reminded to vote in local elections. Once you sign up, we'll help you encourage your friends to vote, too.</p>
-            <ShortInput label="Email" onChange={this.setter('email')} value={this.state.email}/>
-            <ShortInput label="Phone number" onChange={this.setter('phoneNumber')} value={this.state.phoneNumber}/>
-            <div {...style.buttons}>
-              <Link to="/registration-check" theme="transparent">Back</Link>
-              <Button action={this.submit} theme="success">Sign Up</Button>
-            </div>
+            {!Voter.currentUser.signedUp && <form onSubmit={e => { this.submit(); e.preventDefault(); }}>
+              <p>Sign up to be reminded to vote in local elections.</p>
+              <ShortInput label="Email" onChange={this.setter('email')} type="email" value={this.state.email}/>
+              <div {...style.buttons}>
+                <Link to="/registration-check" theme="transparent">Back</Link>
+                <Button action={this.submit} theme="success">Sign Up</Button>
+              </div>
+            </form>}
+            {Voter.currentUser.signedUp && <p>We'll remind you to get ready to vote before the next election.</p>}
           </div>
         </div>
       </MainContentWrapper>

--- a/web_client/app/registration-verified/registration-verified.tsx
+++ b/web_client/app/registration-verified/registration-verified.tsx
@@ -21,6 +21,9 @@ export type RegistrationVerifiedProps = {
 export class RegistrationVerified extends React.Component<RegistrationVerifiedProps, {}> {
   state = {
     email: "",
+    errors: {} as {
+      email: string[]
+    }
   }
 
   setter(name: string) {
@@ -35,7 +38,9 @@ export class RegistrationVerified extends React.Component<RegistrationVerifiedPr
     Voter.currentUser.email = this.state.email;
     Voter.currentUser.signUp().then(
       () => go("/awaiting-confirmation")
-    )
+    ).catch(
+      errors => this.setState({errors: errors})
+    );
   }
 
   render() {
@@ -49,7 +54,7 @@ export class RegistrationVerified extends React.Component<RegistrationVerifiedPr
             <h1 {...style.result}>You&rsquo;re already registered&nbsp;to&nbsp;vote!</h1>
             {!Voter.currentUser.signedUp && <form onSubmit={e => { this.submit(); e.preventDefault(); }}>
               <p>Sign up to be reminded to vote in local elections.</p>
-              <ShortInput label="Email" onChange={this.setter('email')} type="email" value={this.state.email}/>
+              <ShortInput label="Email" onChange={this.setter('email')} errors={this.state.errors.email} type="email" value={this.state.email}/>
               <div {...style.buttons}>
                 <Link to="/registration-check" theme="transparent">Back</Link>
                 <Button action={this.submit} theme="success">Sign Up</Button>

--- a/web_client/app/routes.tsx
+++ b/web_client/app/routes.tsx
@@ -2,17 +2,13 @@ import * as React from 'react';
 import { go, RouteDeclaration, history } from 'router';
 
 // Components
-import { Login } from 'home/login';
+import { Login } from 'login/login';
 import { RegistrationCheck } from 'registration-check/registration-check';
 import { RegistrationVerified } from 'registration-verified/registration-verified';
+import { AwaitingConfirmation } from 'awaiting-confirmation/awaiting-confirmation';
 import { NotRegistered } from 'not-registered/not-registered';
 
 import API from './api/api';
-
-// function requireLogin() {
-//   if (User.loggedIn()) return;
-//   go('/login', { state: { from: history.location } });
-// }
 
 function redirect(path: string) {
   return () => {
@@ -26,6 +22,7 @@ export const routes: RouteDeclaration = {
     { path: 'login', component: Login },
     { path: 'registration-check', component: RegistrationCheck },
     { path: 'registration-verified', component: RegistrationVerified },
+    { path: 'awaiting-confirmation', component: AwaitingConfirmation },
     { path: 'not-registered', component: NotRegistered },
     { path: '/', preFilter: redirect('/registration-check'), component: RegistrationCheck}
   ],

--- a/web_client/app/routes.tsx
+++ b/web_client/app/routes.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { go, RouteDeclaration, history } from 'router';
+import { Voter } from 'models';
 
 // Components
 import { Login } from 'login/login';

--- a/web_client/app/routes.tsx
+++ b/web_client/app/routes.tsx
@@ -13,7 +13,7 @@ import API from './api/api';
 
 function redirect(path: string) {
   return () => {
-    go(path);
+    go(path, {} , true);
   }
 }
 

--- a/web_client/app/routes.tsx
+++ b/web_client/app/routes.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { go, RouteDeclaration, history } from 'router';
 
 // Components
+import { Login } from 'home/login';
 import { RegistrationCheck } from 'registration-check/registration-check';
 import { RegistrationVerified } from 'registration-verified/registration-verified';
 import { NotRegistered } from 'not-registered/not-registered';
@@ -22,6 +23,7 @@ function redirect(path: string) {
 export const routes: RouteDeclaration = {
   path: '/',
   children: [
+    { path: 'login', component: Login },
     { path: 'registration-check', component: RegistrationCheck },
     { path: 'registration-verified', component: RegistrationVerified },
     { path: 'not-registered', component: NotRegistered },


### PR DESCRIPTION
Implment:

- [x] Send emails from the frontend
- [x] Add "I still need an account" link to browser history
- [x] Add frontend validation to require valid email address
- [x] Handle 404 for unknown email addresses
- [x] Show "check your email" messaging if email sent (200). This could either be:
  - A flash/toast message
  - Redirect to an `/email-sent` page
- [x] Check registration status when page loads and redirect

---

- [x] Test email from API:

1. `GET` https://voter-engagement-staging-pr-26.herokuapp.com/api/registration/ with all the required parameters plus `email`
2. Click on the link in the received email
3. Verify it shows your registration status

- [x] Test email from frontend:

1. Go to https://voter-engagement-staging-pr-26.herokuapp.com/login
2. Submit the form using the same email address
3. Click on the link in the received email
4. Verify it shows your registration status




