### PR TITLE
Don't record fullstory in dev

### DIFF
--- a/web_client/app/fullstory/fullstory-snippet.js
+++ b/web_client/app/fullstory/fullstory-snippet.js
@@ -1,0 +1,14 @@
+window['_fs_debug'] = false;
+window['_fs_host'] = 'fullstory.com';
+window['_fs_org'] = 'ARK64';
+window['_fs_namespace'] = 'FS';
+(function(m,n,e,t,l,o,g,y){
+    if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
+    g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[];
+    o=n.createElement(t);o.async=1;o.src='https://'+_fs_host+'/s/fs.js';
+    y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
+    g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){g(l,v)};
+    y="rec";g.shutdown=function(i,v){g(y,!1)};g.restart=function(i,v){g(y,!0)};
+    g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
+    g.clearUserCookie=function(){};
+})(window,document,window['_fs_namespace'],'script','user');

--- a/web_client/app/fullstory/fullstory.tsx
+++ b/web_client/app/fullstory/fullstory.tsx
@@ -3,8 +3,6 @@ declare const PRODUCTION: boolean;
 declare var window: { FS: any };
 var spy: (id: string, o: {}) => void
 
-// TODO maybe doit for some users, for a discount, or sommat
-console.log("OK", PRODUCTION)
 if (PRODUCTION) {
   require('./fullstory-snippet.js');
 

--- a/web_client/app/fullstory/fullstory.tsx
+++ b/web_client/app/fullstory/fullstory.tsx
@@ -1,0 +1,20 @@
+declare const PRODUCTION: boolean;
+
+declare var window: { FS: any };
+var spy: (id: string, o: {}) => void
+
+// TODO maybe doit for some users, for a discount, or sommat
+console.log("OK", PRODUCTION)
+if (PRODUCTION) {
+  require('./fullstory-snippet.js');
+
+  spy = (id: string, object: {} = {}) => {
+    window.FS.identify(id, object);
+  }
+} else {
+  spy = (id: string, object: {} = {}) => {
+    return
+  }
+}
+
+export const spyOnUser = spy;

--- a/web_client/app/index.html
+++ b/web_client/app/index.html
@@ -14,24 +14,6 @@
     <!-- TODO: don't load if unneeded? -->
     <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,fetch,Array.prototype.find,Array.prototype.findIndex&excludes=Promise"></script>
 
-    <!-- FullStory -->
-    <script>
-    window['_fs_debug'] = false;
-    window['_fs_host'] = 'fullstory.com';
-    window['_fs_org'] = 'ARK64';
-    window['_fs_namespace'] = 'FS';
-    (function(m,n,e,t,l,o,g,y){
-        if (e in m) {if(m.console && m.console.log) { m.console.log('FullStory namespace conflict. Please set window["_fs_namespace"].');} return;}
-        g=m[e]=function(a,b){g.q?g.q.push([a,b]):g._api(a,b);};g.q=[];
-        o=n.createElement(t);o.async=1;o.src='https://'+_fs_host+'/s/fs.js';
-        y=n.getElementsByTagName(t)[0];y.parentNode.insertBefore(o,y);
-        g.identify=function(i,v){g(l,{uid:i});if(v)g(l,v)};g.setUserVars=function(v){g(l,v)};
-        y="rec";g.shutdown=function(i,v){g(y,!1)};g.restart=function(i,v){g(y,!0)};
-        g.identifyAccount=function(i,v){o='account';v=v||{};v.acctId=i;g(o,v)};
-        g.clearUserCookie=function(){};
-    })(window,document,window['_fs_namespace'],'script','user');
-    </script>
-
     <base href="/">
     <script type="text/javascript" src="http://localhost:3000/compiled/app.js"></script> <!-- Placeholder script for hot reload -->
   </head>

--- a/web_client/app/main.tsx
+++ b/web_client/app/main.tsx
@@ -1,3 +1,4 @@
+require('fullstory/fullstory');
 import { AppContainer } from 'react-hot-loader';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';

--- a/web_client/app/models/voter/voter.tsx
+++ b/web_client/app/models/voter/voter.tsx
@@ -1,5 +1,6 @@
 import { observable, computed, action } from 'mobx';
 import { VoterService, IncomingRegistrationJSON } from './voter-service';
+import { spyOnUser } from 'fullstory/fullstory';
 
 export class Voter {
   @observable firstName: string
@@ -24,6 +25,7 @@ export class Voter {
   signUp() {
     return VoterService.signUp(this.email, this.firstName, this.lastName, this.birthDate, this.zipCode).then(
       result => {
+        this.registerSpy();
         this.updateFromFetch(result);
         return this.registered;
       }
@@ -39,14 +41,19 @@ export class Voter {
         this.currentUser.updateFromFetch(json);
         this.currentUser.signedUp = true;
         this.currentUserStore.fetched = true;
+        this.currentUser.registerSpy();
         return this.currentUser;
       }
     );
   }
 
-  @computed
   static get currentUser() {
     return this.currentUserStore.currentUser;
+  }
+
+  @action
+  registerSpy() {
+    spyOnUser(this.email, { displayName: `${this.firstName} ${this.lastName}`, email: this.email });
   }
 
   @action
@@ -54,7 +61,7 @@ export class Voter {
     Object.assign(this, json);
   }
 
-  @computed 
+  @computed
   get me() {
     return Voter.currentUserStore.currentUser;
   }


### PR DESCRIPTION
In this PR I pull the fullstory snippet into it's own file, and then use the PRODUCTION variable injected by webpack to decide whether to include that snippet, or use a mock.

I then use an exported function to give fullstory users names and emails.

It's imperfect -- we'll still see traffic from review apps, but we won't see localhost traffic.