### PR TITLE
Add pattern and title attributes to the ZIP code field

### DIFF
--- a/web_client/app/components/forms/short-input/short-input.tsx
+++ b/web_client/app/components/forms/short-input/short-input.tsx
@@ -23,6 +23,8 @@ export interface ShortInputProps {
   value?: string|number
   min?: number
   max?: number
+  pattern?: string
+  title?: string
   autoComplete?: string
 };
 
@@ -36,7 +38,7 @@ export class ShortInput extends React.Component<ShortInputProps, {}> {
   }
 
   render() {
-    const { label, note, type, errors, value, required, flex, min, max } = this.props
+    const { label, note, type, errors, value, required, flex, min, max, pattern, title } = this.props
     return (
       <Labelled {...{ errors, label, note, required, flex }}>
         <input {...css(style.input, errors && style.errorInput) }
@@ -50,6 +52,8 @@ export class ShortInput extends React.Component<ShortInputProps, {}> {
           value={value || ""}
           min={min}
           max={max}
+          pattern={pattern}
+          title={title} // For describing the `pattern` attribute
           onChange={this.onChange} />
         <div {...style.icon}>{this.props.children}</div>
       </Labelled>

--- a/web_client/app/pages/registration-check/registration-check.tsx
+++ b/web_client/app/pages/registration-check/registration-check.tsx
@@ -84,7 +84,9 @@ export class RegistrationCheck extends React.Component<RegistrationCheckProps, {
               onChange={this.setter('zipCode')}
               errors={this.state.errors.zip_code}
               value={this.state.zipCode}
-              autoComplete="postal-code" />
+              autoComplete="postal-code" 
+              title="Five-digit ZIP code"
+              pattern="\\d{5}" />
 
             <div {...css(vars.clearFix)}>
               <Button action={() => {}} css={style.button}>Check!</Button>


### PR DESCRIPTION
Fixes #10
The ShortInput interface is getting a little full... I'd be happy to spend some time moving things like `min`, `max`, `pattern`, etc. into their own type (something like "validation") if anyone thinks that would be worth it.