### PR TITLE
Fix regex pattern for the Registration Check zip code field

### DIFF
--- a/web_client/app/pages/registration-check/registration-check.tsx
+++ b/web_client/app/pages/registration-check/registration-check.tsx
@@ -82,7 +82,7 @@ export class RegistrationCheck extends React.Component<RegistrationCheckProps, {
               value={this.state.zipCode}
               autoComplete="postal-code"
               title="Five-digit ZIP code"
-              pattern="\\d{5}" />
+              pattern="\d{5}" />
 
             <div {...css(vars.clearFix)}>
               <Button theme="secondary" action={() => {}} css={style.button}>Done!</Button>


### PR DESCRIPTION
I'm not sure why the second backslash was necessary when the form was included in a regular page for the legacy app, but not necessary for the chat app. But this fixes it.